### PR TITLE
Cast `true_ref` to upper and be less verbose

### DIFF
--- a/normalize.py
+++ b/normalize.py
@@ -77,7 +77,7 @@ def normalize(pysam_fasta, chrom, pos, ref, alt):
     if alt == '-':
         alt = ''
     # check whether the REF is correct
-    true_ref = pysam_fasta.fetch(chrom, pos - 1, pos - 1 + len(ref))
+    true_ref = pysam_fasta.fetch(chrom, pos - 1, pos - 1 + len(ref)).upper()
     if ref != true_ref:
         raise WrongRefError('Incorrect REF value: %s %s %s %s (actual REF should be %s)'%(chrom, pos, ref, alt, true_ref))
     # Prevent infinte loops in cases where REF == ALT.
@@ -114,7 +114,7 @@ This function takes a tab-delimited file with a header line containing columns
 named chrom, pos, ref, and alt, plus any other columns. It normalizes the
 chrom, pos, ref, and alt, and writes all columns out to another file.
 '''
-def normalize_tab_delimited_file(infile, outfile, reference_fasta, verbose=True):
+def normalize_tab_delimited_file(infile, outfile, reference_fasta, verbose=False):
     pysam_fasta = pysam.FastaFile(reference_fasta) # create a pysam object of the reference genome
     header = infile.readline() # get header of input file
     columns = header.strip('\n').split('\t')  # parse col names 
@@ -147,7 +147,7 @@ def normalize_tab_delimited_file(infile, outfile, reference_fasta, verbose=True)
         data['pos'] = str(pos)
         outfile.write('\t'.join([data[column] for column in columns]) + '\n')
         counter += 1
-        if verbose:
+        if verbose and counter % 1000 == 0:
             sys.stderr.write("\r%s records processed\n"%(counter))
     outfile.write('\n\n')
     if verbose:

--- a/normalize.py
+++ b/normalize.py
@@ -114,7 +114,7 @@ This function takes a tab-delimited file with a header line containing columns
 named chrom, pos, ref, and alt, plus any other columns. It normalizes the
 chrom, pos, ref, and alt, and writes all columns out to another file.
 '''
-def normalize_tab_delimited_file(infile, outfile, reference_fasta, verbose=False):
+def normalize_tab_delimited_file(infile, outfile, reference_fasta, verbose=True):
     pysam_fasta = pysam.FastaFile(reference_fasta) # create a pysam object of the reference genome
     header = infile.readline() # get header of input file
     columns = header.strip('\n').split('\t')  # parse col names 


### PR DESCRIPTION
Since `ref` and `alt` are cast to uppercase, I think `true_ref` should as well.

In addition, make the script much less verbose as it makes for real noisy output in `macarthur-lab/clinvar` and that level of verbosity (one line per entry) is probably not required.